### PR TITLE
Create correct sudoer group for Debian-based  / Redhat-based distros.

### DIFF
--- a/molecule_qemu/playbooks/templates/user-data.j2
+++ b/molecule_qemu/playbooks/templates/user-data.j2
@@ -7,7 +7,14 @@ users:
       - {{ ssh_keypair.public_key }}
   {% if item.network_ssh_user != 'root' -%}
   - name: {{ item.network_ssh_user }}
-    groups: admin,users,sudo,wheel
+    groups:
+      - admin
+      - users
+      {% if ansible_os_family == 'Debian' -%}
+      - sudo
+      {% elif ansible_os_family == 'RedHat' -%}
+      - wheel
+      {%- endif +%}
     shell: /bin/bash
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     lock_passwd: true


### PR DESCRIPTION
On Debian based distros, there is no `wheel`, on Redhat there is no `sudo`.

This avoids creating the superfluous group, which would occupy GID 1000.
Some of my roles depend on a reproducable UID/GID mapping, which is different between production hosts and molecule provisioned hosts.